### PR TITLE
fix chosen path in bower.json to make it work with new bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "example"
   ],
   "dependencies": {
-    "chosen": "https://github.com/harvesthq/chosen/releases/download/v1.1.0/chosen_v1.1.0.zip",
+    "chosen": "https://github.com/harvesthq/bower-chosen#v1.4.2",
     "angular": ">=1.2.0"
   }
 }


### PR DESCRIPTION
with bower version 1.7 the current zip file in the bower.json fails to unzip. This pr fixes that.
